### PR TITLE
Retry at least once when client receives a 401 from service

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ opts = {
   token_path: "/oauth2/token",  # Required. The OAuth token endpoint on the OAuth2 server.
 
   # Below also shows their default values
-  skip_tls_verify:  false,  # Skip verifying the TLS certificate
-  max_retry:        5,      # Maximum number of retries on connection error
-  race_ttl_in_secs: 10,     # Extended TTL for racing condition for cache
-  cache:            nil,    # For example, Rails.cache
-  cache_root:       "sand", # A string as the root namespace in the cache
-  logger:           nil     # For example, Rails.logger
+  skip_tls_verify:     false,  # Skip verifying the TLS certificate
+  default_retry_count: 5,      # Default number of retries on connection error
+  race_ttl_in_secs:    10,     # Extended TTL for racing condition for cache
+  cache:               nil,    # For example, Rails.cache
+  cache_root:          "sand", # A string as the root namespace in the cache
+  logger:              nil     # For example, Rails.logger
 }
 client = Sand::Client.new(opts)
 

--- a/lib/sand/base.rb
+++ b/lib/sand/base.rb
@@ -1,7 +1,7 @@
 module Sand
   class Base
     attr_accessor :client_id, :client_secret, :token_site, :token_path,
-        :race_ttl_in_secs, :skip_tls_verify, :max_retry, :cache, :cache_root, :logger
+        :race_ttl_in_secs, :skip_tls_verify, :default_retry_count, :cache, :cache_root, :logger
 
     # opts = {
     #   client_id: Required
@@ -9,7 +9,8 @@ module Sand
     #   token_site: Required
     #   token_path: Required
     #   skip_tls_verify: Skip verifying the TLS certificate
-    #   max_retry: Maximum number of retries on connection error
+    #   default_retry_count: Default number of retries on connection error
+    #   max_retry: Deprecated. Same as :default_retry_count.
     #   race_ttl_in_secs: Extended TTL for racing condition for cache
     #   cache: For example, Rails.cache
     #   cache_root: A string as the root namespace in the cache
@@ -21,7 +22,8 @@ module Sand
       @token_site = opts.delete(:token_site) { |o| raise ArgumentError.new("#{o} is required") }
       @token_path = opts.delete(:token_path) { |o| raise ArgumentError.new("#{o} is required") }
       @skip_tls_verify = opts.delete(:skip_tls_verify) || false
-      @max_retry = opts.delete(:max_retry) || 5
+      # Support :max_retry for backward compatibility
+      @default_retry_count = opts.delete(:default_retry_count) || opts.delete(:max_retry) || 5
       # Default race ttl to 10 seconds
       @race_ttl_in_secs = opts.delete(:race_ttl_in_secs) || 10
       # If @cache is nil, there will be no caching of tokens.

--- a/lib/sand/service.rb
+++ b/lib/sand/service.rb
@@ -29,7 +29,7 @@ module Sand
     # "Authorization" header. It will extract the token and check with SAND to
     # verify whether the token client is allowed to access this service.
     #
-    # options[:num_retry]: Number of retries is defaulted to @max_retry unless options[:num_retry] is given
+    # options[:num_retry]: Number of retries is defaulted to @default_retry_count unless options[:num_retry] is given
     # on a per request basis. For a service, num_retry is applied when it has problem
     # connecting to Sand for an access token. The token verificatioin
     # does not perform any retry.


### PR DESCRIPTION
Client to service retry must be at least once in case of the client's token is expired, it must retry to get a new token.

For client/service getting a token from Sand, the retry count can be 0. This is not changed.

- [x] @johnny-lai 
- [ ] @tjackiw 