### PR TITLE
CD-99873 URI encode basic auth

### DIFF
--- a/lib/sand/client.rb
+++ b/lib/sand/client.rb
@@ -1,5 +1,6 @@
 require 'oauth2'
 require 'faraday'
+require 'cgi'
 
 module Sand
   class Client < Base
@@ -121,7 +122,7 @@ module Sand
       retry_limit = options[:num_retry] && options[:num_retry].to_i >= 0 ? options[:num_retry].to_i : @max_retry
 
       # The 'auth_scheme' option is for oauth2 1.3.0 gem, but it will work for 1.2 since it's just an option
-      client = OAuth2::Client.new(@client_id, @client_secret,
+      client = OAuth2::Client.new(CGI.escape(@client_id), CGI.escape(@client_secret),
           site: @token_site, token_url: @token_path,
           ssl: {:verify => @skip_tls_verify != true},
           auth_scheme: :basic_auth)

--- a/sand.gemspec
+++ b/sand.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 
-  spec.add_runtime_dependency 'oauth2', '>= 1.2.0'
+  spec.add_runtime_dependency 'oauth2', '>= 1.2.0', '<= 1.4.0'
   spec.add_runtime_dependency 'faraday', '~> 0.9.0'
 end


### PR DESCRIPTION
Sand server's basic auth now expects the username and password to be URI encoded https://github.com/ory/hydra/issues/536

Although I patched Sand's server to accept both encoded or not encoded, we should update the client libraries so that one day we can remove the patch from Sand server.


- [x] @johnny-lai 
- [ ] @tjackiw 