### PR TITLE
Update gemspec to allow newer oauth2 gem because older ones only allo…

### DIFF
--- a/lib/sand/version.rb
+++ b/lib/sand/version.rb
@@ -1,3 +1,3 @@
 module Sand
-  VERSION = "1.3.2"
+  VERSION = "1.3.3"
 end

--- a/sand.gemspec
+++ b/sand.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", ">= 10.0"
   spec.add_development_dependency "rspec", ">= 3.0"
 
-  spec.add_runtime_dependency 'oauth2', '>= 1.2.0', '<= 1.4.0'
+  spec.add_runtime_dependency 'oauth2', '>= 1.2.0'
   spec.add_runtime_dependency 'faraday', '>= 0.9.0'
 end


### PR DESCRIPTION
…w old faraday gems

oauth2 1.4.0 has restricted faraday to < 0.13. This prevents using the latest faraday gem.

oauth2 1.4.2 allows faraday < 2.0.

- [x] @johnny-lai 