### PR TITLE
Remove skip tls verify option and add minimum supported ssl version

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ opts = {
   token_path: "/oauth2/token",  # Required. The OAuth token endpoint on the OAuth2 server.
 
   # Below also shows their default values
-  skip_tls_verify:     false,  # Skip verifying the TLS certificate. Default is not to skip.
+  ssl_min_version:     :TLS1_2,  # Minimum TLS version supported. For Faraday >= v1.0, the default value will be :TLS1_2. For Faraday < v1.0, the value will be :TLSv1_2.
   default_retry_count: 5,      # Default number of retries on connection error
   cache:               nil,    # Always use a cache!! For example, Rails.cache
   cache_root:          "sand", # A string as the root namespace in the cache

--- a/lib/sand/client.rb
+++ b/lib/sand/client.rb
@@ -127,7 +127,7 @@ module Sand
       # The 'auth_scheme' option is for oauth2 1.3.0 gem, but it will work for 1.2 since it's just an option
       client = OAuth2::Client.new(CGI.escape(@client_id), CGI.escape(@client_secret),
           site: @token_site, token_url: @token_path,
-          ssl: {:verify => @skip_tls_verify != true},
+          ssl: { @faraday_ssl_version_key => @ssl_min_version },
           auth_scheme: :basic_auth)
       retry_count = 0
       begin

--- a/lib/sand/service.rb
+++ b/lib/sand/service.rb
@@ -123,7 +123,11 @@ module Sand
         context: options.fetch(:context, @context),
       }
       conn = Faraday.new(url: @token_site) do |faraday|
-        faraday.ssl.verify = false if @skip_tls_verify == true
+        if @faraday_ssl_version_key == :min_version
+          faraday.ssl.min_version = @ssl_min_version
+        else
+          faraday.ssl.version = @ssl_min_version
+        end
         faraday.adapter(Faraday.default_adapter)
       end
       conn.authorization(:Bearer, access_token)


### PR DESCRIPTION
OPS is requiring TLS 1.2. So add the option to set the minimum version of SSL.

Remove the option to skip TLS verify, which was for development purpose in the past.

- [x] @johnny-lai 