### PR TITLE
Let service retry once when encountering 401 accessing token verificat…

### DIFF
--- a/lib/sand/errors.rb
+++ b/lib/sand/errors.rb
@@ -1,4 +1,7 @@
 module Sand
   class AuthenticationError < StandardError
   end
+
+  class ServiceUnauthorizedError < StandardError
+  end
 end


### PR DESCRIPTION
…ion endpoint

Also expire token cache 5 seconds before the actual time to account for network delay, to avoid expired token.

- [x] @abdulchaudhrycoupa 